### PR TITLE
chore(refactor): swap to esm, its 2024 bro

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,13 @@
-var createError = require('http-errors');
-var express = require('express');
-var path = require('path');
-var logger = require('morgan');
+import express from 'express';
+import path from 'path';
+import logger from "morgan";
 
-var indexRouter = require('./routes/index');
+import indexRouter from './routes/index.js';
+
+// https://flaviocopes.com/fix-dirname-not-defined-es-module-scope/
+import { fileURLToPath } from 'url';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 var app = express();
 
@@ -45,4 +49,4 @@ app.use(function(err, req, res, next) {
   res.render('error');
 });
 
-module.exports = app;
+export default app;

--- a/bin/www.js
+++ b/bin/www.js
@@ -4,9 +4,12 @@
  * Module dependencies.
  */
 
-var app = require('../app');
-var debug = require('debug')('go.resonite.com:server');
-var http = require('http');
+import app from '../app.js';
+
+import debugModule from 'debug';
+const debug = new debugModule('go.resonite.com:server');
+
+import http from 'http';
 
 /**
  * Get port from environment and store in Express.

--- a/helpers/preprocessing.js
+++ b/helpers/preprocessing.js
@@ -1,3 +1,5 @@
+import DOMPurify from 'isomorphic-dompurify';
+
 function preProcessName(name) {
     const start = /<color="?(.+?)"?>/gi;
     const end = /<\/color>/gi
@@ -27,7 +29,7 @@ function preProcessWorld(json) {
     return json;
 }
 
-function preProcess(json, type) {
+export function preProcess(json, type) {
 
     // ensure page title
     json.title = DOMPurify.sanitize(json.name);
@@ -44,5 +46,3 @@ function preProcess(json, type) {
 
     return json;
 }
-
-module.exports.preProcess = preProcess;

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "go.resonite.com",
   "version": "0.0.0",
+  "type": "module",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "node ./bin/www.js"
   },
+  "exports": "./start.js",
   "dependencies": {
     "cookie-parser": "~1.4.4",
     "debug": "~2.6.9",

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,8 +1,11 @@
-var express = require('express');
-var createError = require('http-errors');
+import express from 'express';
+
+import pkg from 'http-errors';
+const {createError} = pkg;
+
+import { preProcess } from '../helpers/preprocessing.js';
+
 var router = express.Router();
-var DOMPurify = require("isomorphic-dompurify");
-var preprocessing = require('../helpers/preprocessing');
 
 /* GET home page. */
 router.get('/', function(req, res, next) {
@@ -54,7 +57,7 @@ async function handle(type, req, res, next) {
     return next(createError(400, "go.resonite.com only works for Session and world link."));
   }
 
-  json = preprocessing.preProcess(json, type);
+  json = preProcess(json, type);
   json.urlPath = req.getUrl();
 
   res.status(200).render(type, json);
@@ -74,7 +77,7 @@ async function handleJson(type, req, res, next) {
     return next();
   }
 
-  json = preprocessing.preProcess(json, type);
+  json = preProcess(json, type);
   // title is the TOP link
   var title = getOpenGraphTitle(type);
   res.json({
@@ -98,4 +101,4 @@ function getOpenGraphTitle(type) {
   }
 }
 
-module.exports = router;
+export default router;


### PR DESCRIPTION
One of my pet peeves in the node world(that i've been out of for a bunch of years), is that node js projects always end up falling behind the times.

Updating to esm based modules, helps us keep up to date and lets us move faster.