### PR TITLE
fix: adjust import for http-errors

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -1,7 +1,5 @@
 import express from 'express';
-
-import pkg from 'http-errors';
-const {createError} = pkg;
+import createError from 'http-errors';
 
 import { preProcess } from '../helpers/preprocessing.js';
 


### PR DESCRIPTION
This PR resolves the incorrect importing of `http-errors` that results in the `createError` function to be `undefined`.

Resolves #10 