### PR TITLE
chore: add typedefs and debugging capabilities

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 node_modules/
 *.md
+typedef.js

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Script: debug",
+      "type": "node-terminal",
+      "command": "npm run debug",
+      "request": "launch"
+    },
+    {
+      "name": "Attach to App Process: debug",
+      "type": "node",
+      "port": 9777,
+      "request": "attach",
+      "skipFiles": [
+        "<node_internals>/**"
+      ]
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Debug App",
+      "configurations": ["Run Script: debug", "Attach to App Process: debug"],
+      "stopAll": true
+    }
+  ]
+}

--- a/bin/www.js
+++ b/bin/www.js
@@ -34,8 +34,10 @@ server.on('listening', onListening);
 
 /**
  * Normalize a port into a number, string, or false.
+ * 
+ * @param {string|number} val The possible port number to normalize.
+ * @returns The normalized port number, or false or itself if the value cannot be parsed. 
  */
-
 function normalizePort(val) {
   var port = parseInt(val, 10);
 
@@ -54,8 +56,9 @@ function normalizePort(val) {
 
 /**
  * Event listener for HTTP server "error" event.
+ * 
+ * @param {NodeJS.ErrnoException} error The error that was thrown.
  */
-
 function onError(error) {
   if (error.syscall !== 'listen') {
     throw error;
@@ -83,7 +86,6 @@ function onError(error) {
 /**
  * Event listener for HTTP server "listening" event.
  */
-
 function onListening() {
   var addr = server.address();
   var bind = typeof addr === 'string'

--- a/helpers/preprocessing.js
+++ b/helpers/preprocessing.js
@@ -1,11 +1,23 @@
 import DOMPurify from 'isomorphic-dompurify';
 
+/**
+ * Converts the world or session name to its HTML equivalent.
+ * 
+ * @param {string} name The name of the world or session to sanitize.
+ * @returns The processed world or session name that was sanitized.
+ */
 function preProcessName(name) {
     const start = /<color="?(.+?)"?>/gi;
     const end = /<\/color>/gi
     return name.replace(start, "<span style=\"color: $1;\">").replace(end, "</span>");
 }
 
+/**
+ * Preprocesses the session information returned from SkyFrost to a format suitable for viewing.
+ * 
+ * @param {SessionInfo} json The session object from SkyFrost to transform.
+ * @returns The transformed session object for viewing.
+ */
 function preProcessSession(json) {
     if (!json.thumbnailUrl || json.thumbnailUrl === "")
     {
@@ -19,6 +31,12 @@ function preProcessSession(json) {
     return json;
 }
 
+/**
+ * Preprocesses the world information return from SkyFrost to a format suitable for viewing.
+ * 
+ * @param {WorldInfo} json The world object from SkyFrost to transform.
+ * @returns The preprocessed world information for viewing.
+ */
 function preProcessWorld(json) {
     if (json.thumbnailUri) {
         json.thumbnailUri = json.thumbnailUri.replace("resdb:///", "https://assets.resonite.com/").replace(".webp", "");
@@ -29,6 +47,14 @@ function preProcessWorld(json) {
     return json;
 }
 
+/**
+ * Preprocesses the world or session information returned from SkyFrost
+ * to make it suitable for Web viewing.
+ * 
+ * @param {BaseWorldSessionInfo} json The world or session object from SkyFrost to transform.
+ * @param {('world'|'session')} type The type of information this is whether it is a world or session.
+ * @returns The preprocessed world or session object for viewing.
+ */
 export function preProcess(json, type) {
 
     // ensure page title

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www.js"
+    "start": "node ./bin/www.js",
+    "debug": "node --inspect-brk=9777 ./bin/www.js"
   },
   "exports": "./start.js",
   "dependencies": {

--- a/routes/index.js
+++ b/routes/index.js
@@ -21,6 +21,13 @@ for (const word of ["world", "record"]) {
 
 var baseUrl = "https://api.resonite.com";
 
+/**
+ * Gets the url for either the world or session api endpoint.
+ * 
+ * @param {('world'|'session')} type The type of information this is whether it is a world or session.
+ * @param {import('express').Request} req The web request information.
+ * @returns The world or session api endpoint.
+ */
 function getUrl(type, req) {
   switch (type) {
     case "world":
@@ -32,6 +39,13 @@ function getUrl(type, req) {
   }
 }
 
+/**
+ * Creates an error for the Web response of a failed call to the api.
+ * 
+ * @param {Response} res The response of the api request.
+ * @param {('world'|'session')} type The type of information this is whether it is a world or session.
+ * @returns 
+ */
 async function createResoniteApiError(res, type) {
   if (res.status === 404) {
     return createError(res.status, `We couldn't find this ${type}.\n
@@ -42,6 +56,15 @@ async function createResoniteApiError(res, type) {
   return createError(res.status, `Resonite API returned an error: ${text}`);
 }
 
+/**
+ * Handles a request for world or session information.
+ * 
+ * @param {('world'|'session')} type The type of information this is whether it is a world or session.
+ * @param {import('express').Request} req The web request information.
+ * @param {import('express').Response} res The web response object.
+ * @param {import('express').NextFunction} next The function to call to proceed to the next handler.
+ * @returns 
+ */
 async function handle(type, req, res, next) {
   var apiResponse = await fetch(getUrl(type, req));
   if (!apiResponse.ok) {
@@ -61,6 +84,15 @@ async function handle(type, req, res, next) {
   res.status(200).render(type, json);
 }
 
+/**
+ * Handles a json request for world or session information.
+ * 
+ * @param {('world'|'session')} type The type of information this is whether it is a world or session.
+ * @param {import('express').Request} req The web request information.
+ * @param {import('express').Response} res The web response object.
+ * @param {import('express').NextFunction} next The function to call to proceed to the next handler.
+ * @returns 
+ */
 async function handleJson(type, req, res, next) {
   var apiResponse = await fetch(getUrl(type, req));
   if (!apiResponse.ok) {
@@ -87,6 +119,12 @@ async function handleJson(type, req, res, next) {
   });
 }
 
+/**
+ * Generates a title for OpenGraph based on the requested type.
+ * 
+ * @param {('world'|'session')} type The type of information this is whether it is a world or session.
+ * @returns An OpenGraph suitable title for a world or session.
+ */
 function getOpenGraphTitle(type) {
   var app = "Resonite";
   switch(type) {

--- a/typedef.js
+++ b/typedef.js
@@ -1,0 +1,58 @@
+/**
+ * Common data properties found in a world or session returned by SkyFrost.
+ * 
+ * @typedef {object} BaseWorldSessionInfo
+ * @property  {string} title The plain text name of the world or session.
+ * @property {string} name The rich text name of the world or session.
+ * @property {string} description The description of the world or session.
+*/
+
+/**
+ * The world information returned by SkyFrost.
+ * 
+ * @extends BaseWorldSessionInfo
+ * @typedef {BaseWorldSessionInfo & WorldInfoInternalType} WorldInfo
+*/
+
+/**
+ * The session information returned by SkyFrost.
+ * 
+ * @extends {BaseWorldSessionInfo}
+ * @typedef {BaseWorldSessionInfo & SessionInfoInternalType} SessionInfo
+*/
+
+/**
+ * @typedef {object} User
+ * @property {string} username The username of the user.
+*/
+
+// Internal Types
+
+/**
+ * Used for extending the BaseWorldSessionInfo type with WorldInfo since intellisense does not support
+ * extended or augmented types. Avoid using this outside of extending types.
+ * 
+ * @extends BaseWorldSessionInfo
+ * @typedef {object} WorldInfoInternalType
+ * @property {string} id The record id of the world.
+ * @property {string} ownerName The name of the owner who owns the world.
+ * @property {string} thumbnailUri The thumbnail image of the world as a URL.
+ * @property {string[]} tags Additional tags that help define the world.
+ * @property {string|Date} creationTime The date and time the world was first created on.
+ * @property {string|Date} firstPublishTime The date and time the world was first published on.
+ * @property {string|Date} lastModificationTime The date and tiem the world was last modified on. 
+*/
+
+/**
+ * Used for extending the BaseWorldSessionInfo type with SessionInfo since intellisense does not support
+ * extended or augmented types. Avoid using this outside of extending types.
+ * 
+ * @extends BaseWorldSessionInfo
+ * @typedef {object} SessionInfoInternalType
+ * @property {string} hostUsername The username of the host that is hosting the session.
+ * @property {number} totalJoinedUsers The number of users that are present in the session.
+ * @property {number} maxUsers The max number of users that can be in the session.
+ * @property {string} appVersion The current FrooxEngine version that this session is running on.
+ * @property {User[]} sessionUsers The users in the current session.
+ * @property {string} thumbnailUrl The thumbnail image of the session as a URL.
+ */


### PR DESCRIPTION
This PR is mainly to add JSDoc comments to functions in order for intellisense to recognize what types these arguments are. This should help provide the available functions or properties for the given argument instead of it being inferred as `any`. 

I also added `launch.json` to help start the debugging process for the project.