### PR TITLE
fix(accessibility): address web accessibility failures

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -2,6 +2,10 @@
   --background-body: #11151d;
 }
 
+.subheading {
+  font-size: 1rem;
+}
+
 .center {
   display: flex;
   flex-wrap: wrap;

--- a/routes/index.js
+++ b/routes/index.js
@@ -7,7 +7,9 @@ var router = express.Router();
 
 /* GET home page. */
 router.get('/', function(req, res, next) {
-  res.render('index');
+  res.render('index', {
+    title: 'go.resonite.com Home'
+  });
 });
 
 router.get('/session/:sessionId', (req,res, next) => handle("session", req, res, next));
@@ -42,7 +44,7 @@ function getUrl(type, req) {
 /**
  * Creates an error for the Web response of a failed call to the api.
  * 
- * @param {Response} res The response of the api request.
+ * @param {SessionInfoA} res The response of the api request.
  * @param {('world'|'session')} type The type of information this is whether it is a world or session.
  * @returns 
  */

--- a/views/index.pug
+++ b/views/index.pug
@@ -1,7 +1,7 @@
 extends layout
 
 block content
-    h1 go.resonite.com 
+    h1 go.resonite.com
     p go.resonite.com is used to link to worlds and sessions from the web. It's home page doesn't have any functionality at the moment.
 
     p Would you like to 

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -15,7 +15,7 @@ html(lang="en")
             @import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
 
     header.center
-        img(src='/images/resonite.png')
+        img(src='/images/resonite.png' alt='Resonite')
     body
         block content
             h1 Placeholder

--- a/views/session.pug
+++ b/views/session.pug
@@ -24,7 +24,7 @@ block content
     p.center 
         a(href="https://wiki.resonite.com/go.resonite.com") Need Help?
 
-    h4 Alternative URLs 
+    h2.subheading Alternative URLs 
     ul
         li #[strong Session Url:] #{`ressession:///${sessionId}`}
         li #[strong Connection Urls:] 

--- a/views/session.pug
+++ b/views/session.pug
@@ -13,7 +13,7 @@ block content
     h1 !{name}
 
     .center 
-        img(src=thumbnailUrl)
+        img(src=thumbnailUrl alt=`A preview image of the '${title}' session.`)
 
     ul
         li #[strong Host:] #{hostUsername}

--- a/views/world.pug
+++ b/views/world.pug
@@ -12,7 +12,7 @@ block content
     h1 !{name}
 
     .center 
-        img(src=thumbnailUri)
+        img(src=thumbnailUri alt=`A preview image of the '${title}' world.`)
 
     ul
         li #[strong By:] #{ownerName}

--- a/views/world.pug
+++ b/views/world.pug
@@ -22,6 +22,6 @@ block content
         a.btn(href=`resrec:///${ownerId}/${id}`) Open World!
     p.center 
         a(href="https://wiki.resonite.com/go.resonite.com") Need Help?
-    h4 Alternative URLs 
+    h2.subheading Alternative URLs 
     ul
         li #[strong Record Url:] #{`resrec:///${ownerId}/${id}`}


### PR DESCRIPTION
During my review of the site, I found some web accessibility rules that were failing. Included in this PR are fixes to these issues.

* Images should now have an `alt` attribute.
* The Index page should now have content in the `title` tag.
* Heading order for session and world pages should now be in the correct order.
  * A CSS rule for `.subheading` was added to retain the original size of the `h4` heading.