### PR TITLE
tweak(layout): adjust main layout structure and style

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -2,6 +2,23 @@
   --background-body: #11151d;
 }
 
+html, body {
+  display: flex;
+  height: 100vh;
+  margin: 0;
+}
+
+html {
+  justify-content: center;
+}
+
+body {
+  flex-direction: column;
+  box-sizing: border-box;
+  max-width: 820px;
+  padding: 20px 10px;
+}
+
 .subheading {
   font-size: 1rem;
 }
@@ -15,6 +32,14 @@
 
 * {
   font-family: "Poppins", sans-serif;
+}
+
+.go-page-content {
+  flex: 1;
+}
+
+.go-page-footer {
+  width: 100%;
 }
 
 .btn {

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -13,13 +13,12 @@ html(lang="en")
         block head
         style.
             @import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
-
-    header.center
-        img(src='/images/resonite.png' alt='Resonite')
     body
+        header.center
+            img(src='/images/resonite.png' alt='Resonite')
         block content
             h1 Placeholder
-footer
-    p.center
-        span Copyright © 
-        a(href="https://yellowdogman.com/imprint.html") Yellow Dog Man Studios s.r.o.
+        footer
+            p.center
+                span Copyright © 
+                a(href="https://yellowdogman.com/imprint.html") Yellow Dog Man Studios s.r.o.

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -14,12 +14,12 @@ html(lang="en")
         style.
             @import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
     body
-        header.center
+        header.go-page-header.center
             img(src='/images/resonite.png' alt='Resonite')
-        main
+        main.go-page-content
             block content
                 h1 Placeholder
-        footer
+        footer.go-page-footer
             p.center
                 span Copyright © 
                 a(href="https://yellowdogman.com/imprint.html") Yellow Dog Man Studios s.r.o.

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -16,8 +16,9 @@ html(lang="en")
     body
         header.center
             img(src='/images/resonite.png' alt='Resonite')
-        block content
-            h1 Placeholder
+        main
+            block content
+                h1 Placeholder
         footer
             p.center
                 span Copyright © 


### PR DESCRIPTION
This PR tweaks the main layout of the site by providing the following:

* Wrapping the main content of the page under the [`main`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main) tag to provide a stronger semantic and structural meaning.
* Applying flexbox styling on the body's child elements in order to prevent a "floating" footer when the main body content is relatively small (i.e., a sticky bottom footer).

Additionally, I also fixed the html order in `layout.pug` as the elements were not correctly ordered. For example, `html` should only contain the `head` and `body` tags and not the `header` tag; the `header` tag should be under `body`. `footer` was also corrected by placing it under `body`. Although this is technically corrected after being rendered, it is better that the source reflects the correct placement of these elements.