### PR TITLE
Add lastModificationTime and firstPublishTime to world page

### DIFF
--- a/helpers/preprocessing.js
+++ b/helpers/preprocessing.js
@@ -66,6 +66,11 @@ function preProcessWorld(json) {
         json.thumbnailUri = "/images/noThumbnail.png";
     }
 
+    // Convert to UTC to have a standard timezone
+    // This also helps people document worlds on the wiki
+    json.firstPublishTime = new Date(json.firstPublishTime).toUTCString();
+    json.lastModificationTime = new Date(json.lastModificationTime).toUTCString();
+
     return json;
 }
 

--- a/views/world.pug
+++ b/views/world.pug
@@ -21,6 +21,12 @@ block content
             dt Description: 
             dd #{description}
         .row
+            dt First published on: 
+            dd #{firstPublishTime}
+        .row
+            dt Last modified on: 
+            dd #{lastModificationTime}
+        .row
             dt Tags: 
             dd #{tags.join(", ")}
     div.center


### PR DESCRIPTION
This PR adds some data onto the worlds page, notably:
- lastModificationTime
- firstPublishTime

I thought this could be useful for wiki editors. The time is shown in UTC to avoid timezone conflicts.

Visuals:

![zen_3KigWmZpxK](https://github.com/user-attachments/assets/231abef0-2836-4770-8887-f67999517461)

Tested with: http://localhost:3000/record/U-1Nh1cp42N3Q/R-6d8f2c13-d62c-4148-8972-31a1b6c6b11a