### PR TITLE
feat: World link back on session screen

### DIFF
--- a/views/session.pug
+++ b/views/session.pug
@@ -22,6 +22,10 @@ block content
         .row
             dt Users (#{totalJoinedUsers}/#{maxUsers}): 
             dd #{sessionUsers.map(user => user.username).join(", ")}
+        if correspondingWorldId
+            .row
+                dt World: 
+                a(href=`/world/${correspondingWorldId.ownerId}/${correspondingWorldId.recordId}`) Show world
     div.center
         a.btn(href=`ressession:///${sessionId}`) Join Session!
     p.center 


### PR DESCRIPTION
This PR adds a small link to the world when possible on the session page.

Visual:

![image](https://github.com/user-attachments/assets/6a85e635-fc5f-4824-a164-ecfb120210a9)

Not sure if it would be better to turn this into a proper button, I need feedback on this.