### PR TITLE
feat: add world listing and world search

### DIFF
--- a/helpers/preprocessing.js
+++ b/helpers/preprocessing.js
@@ -2,38 +2,37 @@ import DOMPurify from 'isomorphic-dompurify';
 
 /**
  * Converts the world or session name to its HTML equivalent.
- * 
+ *
  * @param {string} name The name of the world or session to sanitize.
  * @returns The processed world or session name that was sanitized.
  */
 function preProcessName(name) {
-    const start = /<color="?(.+?)"?>/gi;
-    const end = /<\/color>/gi
-    return name.replace(start, "<span style=\"color: $1;\">").replace(end, "</span>");
+  const start = /<color="?(.+?)"?>/gi;
+  const end = /<\/color>/gi
+  return name.replace(start, "<span style=\"color: $1;\">").replace(end, "</span>");
 }
 
 /**
  * Preprocesses the session information returned from SkyFrost to a format suitable for viewing.
- * 
+ *
  * @param {SessionInfo} json The session object from SkyFrost to transform.
  * @returns The transformed session object for viewing.
  */
 function preProcessSession(json) {
-    if (!json.thumbnailUrl || json.thumbnailUrl === "")
-    {
-        json.thumbnailUrl = "/images/noThumbnail.png";
-    }
+  if (!json.thumbnailUrl || json.thumbnailUrl === "") {
+    json.thumbnailUrl = "/images/noThumbnail.png";
+  }
 
-    json.description = `Host: ${json.hostUsername}.\n` +
+  json.description = `Host: ${json.hostUsername}.\n` +
         `Users ${json.totalJoinedUsers}/${json.maxUsers}:${json.sessionUsers.map(user => user.username).join(", ")}.\n`+
-        `Version: ${json.appVersion}`;
+    `Version: ${json.appVersion}`;
 
     return json;
 }
 
 /**
  * Preprocesses the session list and returns an array of the top X sessions to display on the webpage.
- * 
+ *
  * @param {SessionsList} json object of the full session API endpoint
  * @param {SessionCount} int number of sessions to return for the page
  * @returns The transformed sessions object for viewing.
@@ -55,52 +54,71 @@ function preProcessSessionList(json, count){
 
 /**
  * Preprocesses the world information return from SkyFrost to a format suitable for viewing.
- * 
+ *
  * @param {WorldInfo} json The world object from SkyFrost to transform.
  * @returns The preprocessed world information for viewing.
  */
 function preProcessWorld(json) {
-    if (json.thumbnailUri) {
-        json.thumbnailUri = json.thumbnailUri.replace("resdb:///", "https://assets.resonite.com/").replace(".webp", "");
-    } else {
-        json.thumbnailUri = "/images/noThumbnail.png";
-    }
+  if (json.thumbnailUri) {
+    json.thumbnailUri = json.thumbnailUri.replace("resdb:///", "https://assets.resonite.com/").replace(".webp", "");
+  } else {
+    json.thumbnailUri = "/images/noThumbnail.png";
+  }
 
-    // Convert to UTC to have a standard timezone
-    // This also helps people document worlds on the wiki
-    json.firstPublishTime = new Date(json.firstPublishTime).toUTCString();
-    json.lastModificationTime = new Date(json.lastModificationTime).toUTCString();
+  // Convert to UTC to have a standard timezone
+  // This also helps people document worlds on the wiki
+  json.firstPublishTime = new Date(json.firstPublishTime).toUTCString();
+  json.lastModificationTime = new Date(json.lastModificationTime).toUTCString();
 
-    return json;
+  return json;
+}
+
+/**
+ * Preprocesses an array of world information to a format suitable for viewing.
+ *
+ * @param {WorldSearchResult} json The response returned that contains an array of found worlds.
+ * @return {WorldSearchResult} The same preprocessed world passed in.
+ */
+function preProcessWorldList(json) {
+  for (const world of json.records) {
+    world.name = preProcessName(world.name)
+    world.goUri = `/world/${world.ownerId}/${world.id}`
+    preProcessWorld(world)
+  }
+
+  return json;
 }
 
 /**
  * Preprocesses the world or session information returned from SkyFrost
  * to make it suitable for Web viewing.
- * 
+ *
  * @param {BaseWorldSessionInfo} json The world or session object from SkyFrost to transform.
- * @param {('world'|'session')} type The type of information this is whether it is a world or session.
- * @returns The preprocessed world or session object for viewing.
+ * @param {HandleType} type The type of information this is whether it is a world or session.
+ * @return {BaseWorldSessionInfo} The same preprocessed world or session object for viewing.
  */
 export function preProcess(json, type) {
 
-    if (type != "sessionList"){
-        // ensure page title
-        json.title = DOMPurify.sanitize(json.name);
-        json.name = preProcessName(json.name);
+    if (type !== "sessionList" && json.name){
+      // ensure page title
+      json.title = DOMPurify.sanitize(json.name);
+      json.name = preProcessName(json.name);
     }
 
-    switch (type) {
-        case "session":
-        json = preProcessSession(json);
-        break;
-        case "world":
-        json = preProcessWorld(json);
-        break;
-        case "sessionList":
-        json = preProcessSessionList(json, 15);
-        break;
-    }
+  switch (type) {
+    case "session":
+      json = preProcessSession(json);
+      break;
+    case "world":
+      json = preProcessWorld(json);
+      break;
+    case "sessionList":
+      json = preProcessSessionList(json, 15);
+      break;
+    case "worldList":
+      json = preProcessWorldList(json);
+      break;
+  }
 
-    return json;
+  return json;
 }

--- a/helpers/search.js
+++ b/helpers/search.js
@@ -1,0 +1,64 @@
+const MAX_RESULT_COUNT = 20;
+
+/**
+ * Creates the search parameter body used to make a POST request to the Resonite API's Record Search
+ * endpoint.
+ *
+ * @param {string} searchStr The string used to search for worlds.
+ * @param {number} pageIndex The normalized offset that will be multiplied by the count.
+ * @return {RecordApiSearchParameters} The search parameters that can be used to search for particular worlds.
+ */
+function createWorldSerachParams(searchStr, pageIndex) {
+  const searchTerms = searchStr.trim()
+    .split(/\s+/)
+    .filter(term => !!term)
+    .map(term => term.match(/([+-])?(.+)/));
+
+  const optionalTags = [];
+  const requiredTags = [];
+  const excludedTags = [];
+
+  for (const [, modifier, term] of searchTerms) {
+    switch (modifier) {
+      case '+':
+        requiredTags.push(term);
+        break;
+      case '-':
+        excludedTags.push(term);
+        break;
+      default:
+        optionalTags.push(term);
+    }
+  }
+
+  return {
+    recordType: 'world',
+    count: MAX_RESULT_COUNT,
+    offset: MAX_RESULT_COUNT * pageIndex,
+    private: false,
+    sortBy: 'FirstPublishTime',
+    sortDirection: 'Descending',
+    optionalTags,
+    requiredTags,
+    excludedTags
+  };
+}
+
+/**
+ * Creates the initial request object required for making a POST request to the Resonite API's
+ * Record Search endpoint.
+ *
+ * @param {WorldSearchRequestParameters} params The additional search parameters specificed by the user.
+ * @return {RequestInit} The request message that is created
+ */
+export function createSearchRequestInit({ term, pageIndex }) {
+  return {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(
+      createWorldSerachParams(term ?? '', pageIndex ?? 0)
+    )
+  };
+}

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -1,5 +1,6 @@
 :root {
   --background-body: #11151d;
+  --border-radius: 8px;
 }
 
 html, body {
@@ -21,6 +22,13 @@ body {
 
 .subheading {
   font-size: 1rem;
+}
+
+.thumbnail {
+  display: flex;
+  align-items: center;
+  border-radius: var(--border-radius);
+  overflow: hidden;
 }
 
 .center {

--- a/public/stylesheets/worldList.css
+++ b/public/stylesheets/worldList.css
@@ -1,0 +1,93 @@
+:root {
+  --listing-spacing: 8px;
+  --listing-line-clamp: 3;
+}
+
+.listing {
+  display:flex;
+  flex-direction: column;
+  gap: var(--listing-spacing);
+  padding: 0;
+  margin: 0;
+  list-style-type: none;
+}
+
+.listing-item {
+  display: grid;
+  grid-template: auto auto 1fr / 1fr 2fr;
+  grid-template-areas:
+    "thumbnail heading"
+    "thumbnail author"
+    "thumbnail description";
+  gap: var(--listing-spacing);
+  box-sizing: border-box;
+  padding: var(--listing-spacing);
+  border: 1px solid var(--border);
+  border-radius: var(--border-radius);
+  background: var(--background);
+}
+
+.listing-item:hover {
+  text-decoration: none;
+}
+
+.listing-item > p {
+  margin: 0;
+  color: var(--text-main);
+}
+
+.listing-item > .thumbnail {
+  grid-area: thumbnail;
+  align-self: center;
+  justify-self: center;
+  max-width: 280px;
+  max-height: 140px;
+}
+
+.listing-item > .thumbnail > img  {
+  transition: transform ease-out 0.2s;
+}
+
+.listing-item:hover .thumbnail > img {
+  transform: scale(1.15);
+}
+
+.listing-item__heading {
+  grid-area: heading;
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--links);
+}
+
+.listing-item__author {
+  grid-area: author;
+}
+
+.listing-item:hover > .listing-item__heading {
+  text-decoration: underline;
+}
+
+/** https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp **/
+/** https://caniuse.com/css-line-clamp **/
+.listing-item__description {
+  grid-area: description;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: var(--listing-line-clamp);
+  -webkit-box-orient: vertical;
+  line-clamp: var(--listing-line-clamp);
+  align-self: self-start
+}
+
+@media (max-width: 600px) {
+  .listing-item {
+    grid-template: auto auto auto auto / auto;
+    grid-template-areas:
+      "thumbnail"
+      "heading"
+      "author"
+      "description";
+  }
+}

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,6 +4,7 @@ import createError from 'http-errors';
 import { preProcess } from '../helpers/preprocessing.js';
 
 import fs from 'node:fs';
+import { createSearchRequestInit } from '../helpers/search.js';
 
 var router = express.Router();
 
@@ -22,6 +23,9 @@ router.get('/session/:sessionId/json', (req,res, next) => handleJson("session", 
 router.get('/sessions', (req, res, next) => handle("sessionList", req, res, next));
 router.get('/sessions/json', (req, res, next) => handleJson("sessionList", req, res, next));
 
+router.get('/world', (req, res, next) => handle('worldList', req, res, next, createSearchRequestInit(req.params)));
+router.get('/world/json', (req, res, next) => handleJson('worldList', req, res, next, createSearchRequestInit(req.params)));
+
 // Register world/ and record/
 for (const word of ["world", "record"]) {
   router.get(`/${word}/:ownerId/:recordId`, (req,res, next) => handle("world", req, res, next));
@@ -32,8 +36,8 @@ var baseUrl = "https://api.resonite.com";
 
 /**
  * Gets the url for either the world or session api endpoint.
- * 
- * @param {('world'|'session'|'sessionList')} type The type of information this is whether it is a world or session.
+ *
+ * @param {HandleType} type The type of information this is whether it is a world or session.
  * @param {import('express').Request} req The web request information.
  * @returns The world or session api endpoint.
  */
@@ -41,6 +45,8 @@ function getUrl(type, req) {
   switch (type) {
     case "world":
       return `${baseUrl}/users/${req.params.ownerId}/records/${req.params.recordId}/`;
+    case "worldList":
+      return `${baseUrl}/records/pagedSearch`
     case "session":
       return `${baseUrl}/sessions/` + req.params.sessionId;
     case "sessionList":
@@ -53,10 +59,10 @@ function getUrl(type, req) {
 
 /**
  * Creates an error for the Web response of a failed call to the api.
- * 
- * @param {SessionInfoA} res The response of the api request.
- * @param {('world'|'session')} type The type of information this is whether it is a world or session.
- * @returns 
+ *
+ * @param {Response} res The response of the api request.
+ * @param {HandleType} type The type of information this is whether it is a world or session.
+ * @returns
  */
 async function createResoniteApiError(res, type) {
   if (res.status === 404) {
@@ -70,16 +76,17 @@ async function createResoniteApiError(res, type) {
 
 /**
  * Handles a request for world or session information.
- * 
- * @param {('world'|'session')} type The type of information this is whether it is a world or session.
+ *
+ * @param {HandleType} type The type of information this is whether it is a world or session.
  * @param {import('express').Request} req The web request information.
  * @param {import('express').Response} res The web response object.
  * @param {import('express').NextFunction} next The function to call to proceed to the next handler.
- * @returns 
+ * @param {RequestInit?} [reqInit=undefined] The optional request body to send to the API.
+ * @returns
  */
-async function handle(type, req, res, next) {
+async function handle(type, req, res, next, reqInit = undefined) {
   try {
-    var apiResponse = await fetch(getUrl(type, req));
+    var apiResponse = await fetch(getUrl(type, req), reqInit);
     if (!apiResponse.ok) {
       var error = await createResoniteApiError(apiResponse, type);
       return next(error);
@@ -91,7 +98,7 @@ async function handle(type, req, res, next) {
       return next(createError(400, "go.resonite.com only works for Session and world link."));
     }
 
-    if (type === "sessionList"){
+    if (type !== 'world' && type !== 'session'){
       json.title = getOpenGraphTitle(type);
     }
 
@@ -115,17 +122,17 @@ function addMetadata(pageType, json) {
 
 /**
  * Handles a json request for world or session information.
- * 
- * @param {('world'|'session')} type The type of information this is whether it is a world or session.
+ *
+ * @param {HandleType} type The type of information this is whether it is a world or session.
  * @param {import('express').Request} req The web request information.
  * @param {import('express').Response} res The web response object.
  * @param {import('express').NextFunction} next The function to call to proceed to the next handler.
- * @returns 
+ * @param {RequestInit?} [reqInit=undefined] The optional request body to send to the API.
+ * @returns
  */
-async function handleJson(type, req, res, next) {
-
+async function handleJson(type, req, res, next, reqInit = undefined) {
   try {
-    var apiResponse = await fetch(getUrl(type, req));
+    var apiResponse = await fetch(getUrl(type, req), reqInit);
     if (!apiResponse.ok) {
       res.status(apiResponse.status);
       return next();
@@ -140,6 +147,7 @@ async function handleJson(type, req, res, next) {
 
     json = preProcess(json, type);
     var title = getOpenGraphTitle(type);
+
     res.json({
       title: title,
       author_name: title,
@@ -155,8 +163,8 @@ async function handleJson(type, req, res, next) {
 
 /**
  * Generates a title for OpenGraph based on the requested type.
- * 
- * @param {('world'|'session')} type The type of information this is whether it is a world or session.
+ *
+ * @param {HandleType} type The type of information this is whether it is a world or session.
  * @returns An OpenGraph suitable title for a world or session.
  */
 function getOpenGraphTitle(type) {
@@ -168,7 +176,8 @@ function getOpenGraphTitle(type) {
       return `${app} World`;
     case "sessionList":
       return `${app} Sessions list`;
-      break;
+    case "worldList":
+      return `${app} World List`;
     default:
       return `${app} World`;
   }

--- a/typedef.d.ts
+++ b/typedef.d.ts
@@ -1,0 +1,27 @@
+type HandleType = 'world' | 'worldList' | 'session' | 'sessionList'
+
+type RecordApiSearchSortField = 'CreationDate' | 'LastUpdateDate' | 'FirstPublishTime'
+
+type RecordApiSearchSortDirection = 'Ascending' | 'Descending'
+
+type RecordApiSearchParameters = {
+  recordType: string
+  count: number
+  offset: number
+  private: boolean
+  requiredTags: string[]
+  optionalTags: string[]
+  excludedTags: string[]
+  sortBy: RecordApiSearchSortField
+  sortDirection: RecordApiSearchSortDirection
+}
+
+type WorldSearchRequestParameters = import('express-serve-static-core').ParamsDictionary | {
+  term?: string
+  pageIndex: number
+}
+
+type WorldSearchResult = {
+  hasMoreResults: boolean
+  records: WorldInfo[]
+}

--- a/typedef.js
+++ b/typedef.js
@@ -1,6 +1,6 @@
 /**
  * Common data properties found in a world or session returned by SkyFrost.
- * 
+ *
  * @typedef {object} BaseWorldSessionInfo
  * @property  {string} title The plain text name of the world or session.
  * @property {string} name The rich text name of the world or session.
@@ -9,14 +9,14 @@
 
 /**
  * The world information returned by SkyFrost.
- * 
+ *
  * @extends BaseWorldSessionInfo
  * @typedef {BaseWorldSessionInfo & WorldInfoInternalType} WorldInfo
 */
 
 /**
  * The session information returned by SkyFrost.
- * 
+ *
  * @extends {BaseWorldSessionInfo}
  * @typedef {BaseWorldSessionInfo & SessionInfoInternalType} SessionInfo
 */
@@ -31,22 +31,24 @@
 /**
  * Used for extending the BaseWorldSessionInfo type with WorldInfo since intellisense does not support
  * extended or augmented types. Avoid using this outside of extending types.
- * 
+ *
  * @extends BaseWorldSessionInfo
  * @typedef {object} WorldInfoInternalType
  * @property {string} id The record id of the world.
  * @property {string} ownerName The name of the owner who owns the world.
+ * @property {string} ownerId the id of the owner who owns the world.
  * @property {string} thumbnailUri The thumbnail image of the world as a URL.
  * @property {string[]} tags Additional tags that help define the world.
  * @property {string|Date} creationTime The date and time the world was first created on.
+ * @property {string} goUri The url of the world for go.resonite.com.
  * @property {string|Date} firstPublishTime The date and time the world was first published on.
- * @property {string|Date} lastModificationTime The date and tiem the world was last modified on. 
+ * @property {string|Date} lastModificationTime The date and tiem the world was last modified on.
 */
 
 /**
  * Used for extending the BaseWorldSessionInfo type with SessionInfo since intellisense does not support
  * extended or augmented types. Avoid using this outside of extending types.
- * 
+ *
  * @extends BaseWorldSessionInfo
  * @typedef {object} SessionInfoInternalType
  * @property {string} hostUsername The username of the host that is hosting the session.

--- a/views/worldList.pug
+++ b/views/worldList.pug
@@ -1,0 +1,19 @@
+extends layout
+
+block head
+  meta(property="og:description" content="Published worlds on Resonite")
+  link(type="application/json+oembed" href=`${urlPath}json`)
+  link(rel='stylesheet' href='/stylesheets/worldList.css')
+
+block content
+  h1 World List
+  ol.listing
+    each world in records
+      li
+        a(href=`${world.goUri}`).listing-item
+          h2.listing-item__heading !{world.name}
+          p.listing-item__author
+            em By #{world.ownerName}
+          div.thumbnail
+            img(src=`${world.thumbnailUri}`, alt='', width='280', height='140', loading='lazy')
+          p.listing-item__description #{world.description || '(No Description)'}


### PR DESCRIPTION
*This is currently being worked on. The main body of this PR will be updated as progress is made. Please feel free to provide any feedback on the information provided in this PR or the changes being made.*

This PR adds the following features to go.resonite.com based on #17:

- [X] World Listing
- [ ] World Search Box
- [ ] Paging Controls for World Browsing

Items marked as completed are in this PR.

## World Listing

Currently, the look and feel of the world listing page mimics that of what you would typically see when performing a web search via a search engine. This is how the current listing looks currently:

![image](https://github.com/user-attachments/assets/58c08b63-bd9d-424c-b08e-f0df9dbbb215)


Resolves #17 