### PR TITLE
Add specific error message on 403

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -62,6 +62,8 @@ async function createResoniteApiError(res, type) {
   if (res.status === 404) {
     return createError(res.status, `We couldn't find this ${type}.\n
     Check your link is valid, and that the session is still open and publicly viewable.`);
+  } else if (res.status === 403) {
+    return createError(res.status, "This world is not published, therefore not publicly viewable.");
   }
 
   var text = await res.text();


### PR DESCRIPTION
Adds:
- Proper error message on 403: Forbidden (meaning the world is generally not published)

Test URL: http://localhost:3000/record/U-j4/R-903687cd-8b3c-4951-8c21-b91f62a50a90