### PR TITLE
fix: description color tag

### DIFF
--- a/helpers/preprocessing.js
+++ b/helpers/preprocessing.js
@@ -64,6 +64,10 @@ function preProcessSessionList(json, count){
  * @returns The preprocessed world information for viewing.
  */
 function preProcessWorld(json) {
+  if (json.description) {
+    json.description = preProcessName(json.description);
+  }
+
   if (json.thumbnailUri) {
     json.thumbnailUri = json.thumbnailUri.replace("resdb:///", "https://assets.resonite.com/").replace(".webp", "");
   } else {

--- a/views/world.pug
+++ b/views/world.pug
@@ -21,7 +21,7 @@ block content
             dd #{ownerName}
         .row
             dt Description: 
-            dd #{description}
+            dd !{description}
         .row
             dt First published on: 
             dd #{firstPublishTime}

--- a/views/worldList.pug
+++ b/views/worldList.pug
@@ -29,7 +29,7 @@ block content
               em By #{world.ownerName}
             div.thumbnail
               img(src=`${world.thumbnailUri}`, alt='', width='280', height='140', loading='lazy')
-            p.listing-item__description #{world.description || '(No Description)'}
+            p.listing-item__description !{world.description || '(No Description)'}
     +pagination(urlPath, apiInitBody.offset + 1, apiInitBody.offset + records.length, [query.pageIndex, parseInt(query.pageIndex) + 1])
   else
     p


### PR DESCRIPTION
There are a lot of color tags in the description, making the page very long.

![image](https://github.com/user-attachments/assets/e5a7d6c3-4cba-4d59-a419-44bc41f750c7)
![image](https://github.com/user-attachments/assets/3a5ae92a-3793-44c8-898b-5864c1410bdd)

The corrected appearance looks like this.

![image](https://github.com/user-attachments/assets/7c8f8705-c79e-4f46-8f4e-7f39dac31fb2)
![image](https://github.com/user-attachments/assets/9fb6fd0a-86f8-4de2-b466-347b0384f1af)
