### PR TITLE
feat: Add visit count to world info

### DIFF
--- a/views/world.pug
+++ b/views/world.pug
@@ -37,6 +37,9 @@ block content
             dt Last modified on: 
             dd #{lastModificationTime}
         .row
+            dt Visits: 
+            dd #{visits}
+        .row
             dt Tags: 
             dd #{tags.join(", ")}
     div.center


### PR DESCRIPTION
Simply adds the world's visit count to the world page

![image](https://github.com/user-attachments/assets/cc95a921-5fd4-4b11-bd19-b08d216db419)

I decided to use the same placement as the in game world browser