### PR TITLE
fix(title): remove all tags for plaintext-only value

### DIFF
--- a/helpers/preprocessing.js
+++ b/helpers/preprocessing.js
@@ -108,7 +108,9 @@ function preProcessWorldList(json) {
 export function preProcess(json, type) {
 
     if (type !== "sessionList"  && json.name){
-        json.title = DOMPurify.sanitize(json.name); // No tags in title
+        json.title = DOMPurify.sanitize(json.name, {
+          ALLOWED_TAGS: []
+        }); // No tags in title
 
         // Handle name for inclusion in the actual page.
         json.name = preProcessName(json.name);


### PR DESCRIPTION
This PR fixes OpenGraph embeds that are showing some markup tags on titles and on the browser tab by disallowing all tags when sanitizing the name. `DOMPurify.sanitize` requires an explicit empty array for `ALLOW_TAGS` since the function will allow some tags through such as `i`.

![image](https://github.com/user-attachments/assets/67357aad-6e92-4619-a04e-577878f5d01d)

Fixes https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/3903