### PR TITLE
fix: parse color values recognized by Resonite only

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -19,10 +19,10 @@
   --color-mid-purple: #824aab;
   --color-sub-purple: #492f64;
   --color-dark-purple: #241e35;
-  --color-hero-blue: #61d1fa;
-  --color-mid-blue: #458fab;
-  --color-sub-blue: #284c5d;
-  --color-dark-blue: #1a2a36;
+  --color-hero-cyan: #61d1fa;
+  --color-mid-cyan: #458fab;
+  --color-sub-cyan: #284c5d;
+  --color-dark-cyan: #1a2a36;
   --color-hero-orange: #e69e50;
   --color-mid-orange: #976c3d;
   --color-sub-orange: #48392a;
@@ -114,15 +114,15 @@ footer {
 }
 
 .btn--blue {
-  background-color: var(--color-mid-blue);
+  background-color: var(--color-mid-cyan);
 }
 
 .btn--blue:hover {
-  background-color: var(--color-sub-blue)
+  background-color: var(--color-sub-cyan)
 }
 
 .btn--blue:active {
-  background-color: var(--color-dark-blue);
+  background-color: var(--color-dark-cyan);
 }
 
 .btn--disabled {
@@ -149,7 +149,7 @@ footer {
 .btn--icon-only.btn--blue:hover,
 .btn--icon-only.btn--blue:focus {
   background: none;
-  color: var(--color-hero-blue)
+  color: var(--color-hero-cyan)
 }
 
 .btn--icon-only:hover {
@@ -161,11 +161,11 @@ footer {
 }
 
 .btn--icon-only.btn--blue:hover {
-  background-color: var(--color-dark-blue);
+  background-color: var(--color-dark-cyan);
 }
 
 .btn--icon-only.btn--blue:active {
-  background-color: var(--color-sub-blue);
+  background-color: var(--color-sub-cyan);
 }
 
 .btn svg {

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -1,4 +1,8 @@
 :root {
+  --color-neutrals-dark: #11151d;
+  --color-neutrals-mid: #2b2f35;
+  --color-neutrals-sub: #86888b;
+  --color-neutrals-light: #e1e1e0;
   --color-hero-yellow: #f8f770;
   --color-mid-yellow: #a0a14e;
   --color-sub-yellow: #484a2c;
@@ -7,11 +11,22 @@
   --color-mid-green: #3f9e44;
   --color-sub-green: #24512c;
   --color-dark-green: #192d24;
+  --color-hero-red: #ff7676; 
+  --color-mid-red: #ae5458;
+  --color-sub-red: #5d323a;
+  --color-dark-red: #1a1318;
+  --color-hero-purple: #ba64f2;
+  --color-mid-purple: #824aab;
+  --color-sub-purple: #492f64;
+  --color-dark-purple: #241e35;
   --color-hero-blue: #61d1fa;
   --color-mid-blue: #458fab;
   --color-sub-blue: #284c5d;
   --color-dark-blue: #1a2a36;
-  --color-hero-red: #ff7676; 
+  --color-hero-orange: #e69e50;
+  --color-mid-orange: #976c3d;
+  --color-sub-orange: #48392a;
+  --color-dark-orange: #292423;
   --background-body: #11151d;
   --border-radius: 8px;
   --btn--icon-only-size: 36px;


### PR DESCRIPTION
This PR aims to incorporate platform color palette name parsing that is specified in the `color` tag (ex., `<color hero.cyan>`). Currently, the PR is a draft as I am still working on this; I wanted to let others know that it is being worked on.

Fixes #42