### PR TITLE
fix(mmc): ignore worlds created by CJ

### DIFF
--- a/helpers/mmc.js
+++ b/helpers/mmc.js
@@ -71,10 +71,8 @@ export function addMMC(worldRecord) {
                 entered: false,
                 error: "Invalid Competition Tag"
             }
-            return worldRecord;
-        } else {
-            return worldRecord;
         }
+        return worldRecord;
     }
 
     var categories = matchCategories(worldRecord.tags);

--- a/helpers/mmc.js
+++ b/helpers/mmc.js
@@ -65,6 +65,10 @@ function matchCategories(tags) {
 }
 
 export function addMMC(worldRecord) {
+    if (worldRecord.ownerId === 'G-Creator-Jam') {
+      return worldRecord;
+    }
+
     if (!worldRecord.tags.includes(competitionTag)) {
         if (worldRecord.tags.includes(competitionTag.toUpperCase())) {
             worldRecord.mmc = {


### PR DESCRIPTION
The kickoff theater for MMC25 is currently listed as an MMC entry; this should not be listed as a competition entry. This PR will ignore worlds created by the CJ group when that world contains the `mmc25` tag.

<img width="628" alt="image" src="https://github.com/user-attachments/assets/9963fbb6-67f5-4892-82b2-0c9d25fb71a7" />
