### PR TITLE
feat(session): add join session attempt function

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -69,7 +69,7 @@ async function createResoniteApiError(res, type) {
     return createError(res.status, `We couldn't find this ${type}.\n
     Check your link is valid, and that the session is still open and publicly viewable.`);
   } else if (res.status === 403) {
-    return createError(res.status, "This world is not published, therefore not publicly viewable.");
+    return createError(res.status, "This world is not published; therefore, it is not publicly viewable.");
   }
 
   var text = await res.text();

--- a/routes/index.js
+++ b/routes/index.js
@@ -91,6 +91,10 @@ async function createResoniteApiError(res, type, id = "") {
  * @returns
  */
 async function handle(type, req, res, next, reqInit = undefined) {
+  if (type === "session" && 'force' in req.query && req.get('Sec-Fetch-User')) {
+    return res.redirect(`ressession:///${req.params.sessionId}`);
+  }
+
   try {
     var apiResponse = await fetch(getUrl(type, req), reqInit);
     if (!apiResponse.ok) {

--- a/routes/index.js
+++ b/routes/index.js
@@ -62,12 +62,16 @@ function getUrl(type, req) {
  *
  * @param {Response} res The response of the api request.
  * @param {HandleType} type The type of information this is whether it is a world or session.
+ * @param {string} [id=""] The world or session id.
  * @returns
  */
-async function createResoniteApiError(res, type) {
+async function createResoniteApiError(res, type, id = "") {
   if (res.status === 404) {
     return createError(res.status, `We couldn't find this ${type}.\n
-    Check your link is valid, and that the session is still open and publicly viewable.`);
+    Please check that your link is valid and the ${type} is still publicly viewable.`, {
+      handleType: type,
+      [`${type}Id`]: id
+    });
   } else if (res.status === 403) {
     return createError(res.status, "This world is not published; therefore, it is not publicly viewable.");
   }
@@ -90,7 +94,8 @@ async function handle(type, req, res, next, reqInit = undefined) {
   try {
     var apiResponse = await fetch(getUrl(type, req), reqInit);
     if (!apiResponse.ok) {
-      var error = await createResoniteApiError(apiResponse, type);
+      const { sessionId, recordId } = req.params
+      var error = await createResoniteApiError(apiResponse, type, sessionId ?? recordId);
       return next(error);
     }
 

--- a/views/error.pug
+++ b/views/error.pug
@@ -2,5 +2,7 @@ extends layout
 
 block content
   h1= error.status
-  h2= error.message 
-  pre #{error.stack}
+  p= error.message
+  if error.stack
+    h2 Stack Trace Info
+    pre #{error.stack}

--- a/views/error.pug
+++ b/views/error.pug
@@ -3,6 +3,9 @@ extends layout
 block content
   h1= error.status
   p= error.message
+  if error.handleType === 'session'
+    p
+      a(href=`ressession:///${error.sessionId}`) Try joining session in Resonite.
   if error.stack
     h2 Stack Trace Info
     pre #{error.stack}


### PR DESCRIPTION
In response to #46, this PR adds the ability to join a session if that session cannot be found by the Cloud. I believe that the proposal in #46 is justified given that the following can already be done in Resonite as mentioned in https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/4023:

> * Copying and pasting a session id into resonite will try to join it
> * Copying and pasting a network url into resonite will try to join it.

Additionally, I added an additional query parameter to session URLs that will automatically open the session in Resonite if the parameter `force` is specified. There is a check performed if a human initiated the request by checking the existence of `Sec-Fetch-User`. This was done to help OpenGraph bypass the redirect, assuming that OpenGraph requests do not include this particular header.

Resolves #46 