### PR TITLE
feat(mmc): enhance parsing for improved accuracy

### DIFF
--- a/config/mmc/init.js
+++ b/config/mmc/init.js
@@ -1,0 +1,59 @@
+import { readdirSync, readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+/** @type Map<string, MmcConfig> */
+export const mmcCompetitionFullDataMap = new Map(crawlConfigs());
+/** @type Set<string> */
+export const validCompetitionTags = new Set(mmcCompetitionFullDataMap.keys());
+
+function* crawlConfigs() {
+  const mmcDirPath = dirname(fileURLToPath(import.meta.url));
+  const mmcConfigFilePaths = readdirSync(mmcDirPath)
+    .filter((filename) => filename.endsWith(".json"))
+    .map((filename) => join(mmcDirPath, filename))
+    .sort()
+
+  for (const fullpath of mmcConfigFilePaths) {
+    /** @type MmcConfig */
+    const config = JSON.parse(readFileSync(fullpath), (key, value) => {
+      switch (key) {
+        case "startDate":
+        case "endDate":
+          return new Date(value);
+        case "categories":
+          return captureCategories(value);
+        default:
+          return value;
+      }
+    })
+
+    const { competitionTag, competitionOtherTag } = config;
+
+    yield [competitionTag, config];
+
+    if (competitionOtherTag) {
+      yield [competitionOtherTag, config];
+    }
+  }
+}
+
+function captureCategories(value, capturedCategories = [], parent = null) {
+  for (const [tag, categoryConfigValue] of Object.entries(value)) {
+    const categoryNode = {
+      parent,
+      requiredTags: [...(parent?.requiredTags ?? []), tag]
+    };
+
+    if (String(categoryConfigValue) === categoryConfigValue) {
+      capturedCategories.push(Object.freeze({
+        title: categoryConfigValue,
+        ...categoryNode,
+        tagKey: categoryNode.requiredTags.join(':').toLowerCase()
+      }));
+    } else {
+      captureCategories(categoryConfigValue, capturedCategories, categoryNode);
+    }
+  }
+  return capturedCategories;
+}

--- a/config/mmc/mmc20.json
+++ b/config/mmc/mmc20.json
@@ -1,0 +1,16 @@
+{
+  "year": 2020,
+  "competitionTag": "mmc",
+  "competitionOtherTag": "MMC",
+  "startDate": "2020-09-01T18:00:00.000Z",
+  "endDate": "2020-10-10T18:00:00.000Z",
+  "wikiPath": "MMC_2020",
+  "categories": {
+    "world": "World",
+    "avatar": "Avatars",
+    "other": "Gadget/Tools+",
+    "World": "World",
+    "Avatar": "Avatar",
+    "Other": "Gadget/Tools+"
+  }
+}

--- a/config/mmc/mmc21.json
+++ b/config/mmc/mmc21.json
@@ -1,0 +1,24 @@
+{
+  "year": 2021,
+  "competitionTag": "mmc21",
+  "startDate": "2021-09-01T18:00:00.000Z",
+  "endDate": "2021-10-16T18:00:00.000Z",
+  "wikiPath": "MMC_2021",
+  "categories": {
+    "world": {
+      "social": "World: Social",
+      "game": "World: Game",
+      "misc": "World: Misc"
+    },
+    "avatar": {
+      "avatars": "Avatar: Avatars",
+      "accessories": "Avatar: Accessories",
+      "misc": "Avatar: Miscellaneous"
+    },
+    "other": {
+      "tau": "Other: TAU",
+      "misc": "Other: Misc"
+    },
+    "meme": "Meme"
+  }
+}

--- a/config/mmc/mmc22.json
+++ b/config/mmc/mmc22.json
@@ -1,0 +1,26 @@
+{
+  "year": 2022,
+  "competitionTag": "mmc22",
+  "startDate": "2022-02-01T19:00:00.000Z",
+  "endDate": "2022-03-19T19:00:00.000Z",
+  "wikiPath": "MMC_2022",
+  "categories": {
+    "world": {
+      "social": "World: Social",
+      "game": "World: Game",
+      "misc": "World: Misc"
+    },
+    "avatar": {
+      "avatars": "Avatar: Avatars",
+      "accessories": "Avatar: Accessories",
+      "misc": "Avatar: Miscellaneous"
+    },
+    "other": {
+      "tau": "Other: TAU",
+      "misc": "Other: Misc"
+    },
+    "art": "Art",
+    "esd": "Education/Science/Dataviz (ESD)",
+    "meme": "Meme"
+  }
+}

--- a/config/mmc/mmc23.json
+++ b/config/mmc/mmc23.json
@@ -1,0 +1,26 @@
+{
+  "year": 2023,
+  "competitionTag": "mmc23",
+  "startDate": "2023-02-01T19:00:00.000Z",
+  "endDate": "2023-03-18T19:00:00.000Z",
+  "wikiPath": "MMC_2023",
+  "categories": {
+    "world": {
+      "social": "World: Social",
+      "game": "World: Game",
+      "misc": "World: Misc"
+    },
+    "avatar": {
+      "avatars": "Avatar: Avatars",
+      "accessories": "Avatar: Accessories",
+      "misc": "Avatar: Miscellaneous"
+    },
+    "other": {
+      "tau": "Other: TAU",
+      "misc": "Other: Misc"
+    },
+    "art": "Art",
+    "esd": "Education/Science/Dataviz (ESD)",
+    "meme": "Meme"
+  }
+}

--- a/config/mmc/mmc24.json
+++ b/config/mmc/mmc24.json
@@ -1,0 +1,26 @@
+{
+  "year": 2024,
+  "competitionTag": "mmc24",
+  "startDate": "2024-02-01T19:00:00.000Z",
+  "endDate": "2024-03-23T19:00:00.000Z",
+  "wikiPath": "MMC_2024",
+  "categories": {
+    "world": {
+      "social": "World: Social",
+      "game": "World: Game",
+      "misc": "World: Misc"
+    },
+    "avatar": {
+      "avatars": "Avatar: Avatars",
+      "misc": "Avatar: Miscellaneous"
+    },
+    "other": {
+      "tau": "Other: TAU",
+      "misc": "Other: Misc"
+    },
+    "art": "Art",
+    "esd": "Education/Science/Dataviz (ESD)",
+    "meme": "Meme",
+    "narrative": "Narrative"
+  }
+}

--- a/config/mmc/mmc25.json
+++ b/config/mmc/mmc25.json
@@ -1,0 +1,26 @@
+{
+  "year": 2025,
+  "competitionTag": "mmc25",
+  "startDate": "2025-02-01T19:00:00.000Z",
+  "endDate": "2025-03-22T19:00:00.000Z",
+  "wikiPath": "MMC_2025",
+  "categories": {
+    "world": {
+      "social": "World: Social",
+      "game": "World: Game",
+      "misc": "World: Misc"
+    },
+    "avatar": {
+      "avatars": "Avatar: Avatars",
+      "misc": "Avatar: Miscellaneous"
+    },
+    "other": {
+      "tau": "Other: TAU",
+      "misc": "Other: Misc"
+    },
+    "art": "Art",
+    "esd": "Education/Science/Dataviz (ESD)",
+    "meme": "Meme",
+    "narrative": "Narrative"
+  }
+}

--- a/typedef.d.ts
+++ b/typedef.d.ts
@@ -122,3 +122,13 @@ type MmcCategory = {
   /** A unique key to help distinguish the category from others. */
   tagKey: string
 }
+
+/**
+ * The search result model when searching for a particular MMC configuration.
+ */
+type MmcConfigSearchResult = {
+  /** The MMC configuration found. */
+  mmcConfig: MmcConfig
+  /** `true` if the competition tag found in the world's tags is valid (i.e., the casing matches); otherwise, `false`. */
+  isValidCompetitionTag: boolean
+}

--- a/typedef.d.ts
+++ b/typedef.d.ts
@@ -87,3 +87,38 @@ type SessionInfo = BaseWorldSessionInfo | {
   /** The thumbnail image of the session as a URL. */
   thumbnailUrl: string
 }
+
+/**
+ * Configuration data used to examine a world and determine if it is an MMC entry.
+ */
+type MmcConfig = {
+  /** The year that the MMC event was hosted in. */
+  year: number
+  /** The identifying competition tag for the MMC event. */
+  competitionTag: string
+  /** An additional identifying competition tag for the MMC event. */
+  competitionOtherTag?: string
+  /** The official start date of the competition. This is usually the kickoff date. */
+  startDate: Date
+  /** The official end date of the competition. This is usually the awards ceremony date. */
+  endDate: Date
+  /** The relative URL path of the Wiki page for the MMC event. */
+  wikiPath: string
+  /** The list of categories that an entry can be tagged with. */
+  categories: MmcCategory[]
+}
+
+/**
+ * MMC category data that contains either a friendly name of the category or
+ * a map of additional `MmcCategory` objects (i.e., subcategories).
+ */
+type MmcCategory = {
+  /** The friendly name of the category. */
+  title: string
+  /** The parent category of this category. If `null`, then this  */
+  parent: MmcCategory
+  /** The tags that are required for the category.*/
+  requiredTags: string[]
+  /** A unique key to help distinguish the category from others. */
+  tagKey: string
+}

--- a/views/mixins/mmc.pug
+++ b/views/mixins/mmc.pug
@@ -1,11 +1,11 @@
 mixin mmcMixin(mmcData)
     section.mmc
         h2
-            | MMC 2025 Information
+            | MMC #{mmcData.year} Information
             img(src='/images/CreatorJam.png')
         ul
             if (mmcData.entered)
-                li ✅ This world is entered into the MMC 2025!
+                li ✅ This world is entered into MMC #{mmcData.year}!
                 if isPublished
                     li ✅ This world is published!
                 else
@@ -20,6 +20,5 @@ mixin mmcMixin(mmcData)
                 if mmcData.categories.length == 0
                     li.warning ❌ It is entered into no categories.
             else
-                li.warning ❌ This world is #[strong NOT] entered into the MMC 2025, due to: !{mmcData.error}
-
-    p See #[a(href='https://wiki.resonite.com/MMC_2025') our wiki] for more information on MMC.
+                li.warning ❌ This world is #[strong NOT] entered into MMC #{mmcData.year}, due to: !{mmcData.error}
+        p See #[a(href=`https://wiki.resonite.com/${mmcData.wikiPath}`) our wiki] for more information on MMC #{mmcData.year}.

--- a/views/mixins/mmc.pug
+++ b/views/mixins/mmc.pug
@@ -11,14 +11,14 @@ mixin mmcMixin(mmcData)
                 else
                     li.warning ❌ This world is #[strong NOT] published!
                 if mmcData.categories.length > 0
-                li It is entered into the following Categories:
-                    ul
-                        each category in mmcData.categories
-                            li ✅ !{category.title}
+                    li It is entered into the following Categories:
+                        ul
+                            each category in mmcData.categories
+                                li ✅ !{category.title}
                 if mmcData.categories.length > 1
                     li.warning ❌ It is entered into more than one category.
                 if mmcData.categories.length == 0
-                    li.warning ❌ It is entered into no categories.
+                    li.warning ❌ It is #[strong NOT] entered into any categories.
             else
                 li.warning ❌ This world is #[strong NOT] entered into MMC #{mmcData.year}, due to: !{mmcData.error}
         p See #[a(href=`https://wiki.resonite.com/${mmcData.wikiPath}`) our wiki] for more information on MMC #{mmcData.year}.


### PR DESCRIPTION
This PR enhances the MMC parser used to determine MMC entries. It will now restrict adding MMC information to entries if the entry's publish time or creation time (publish time receives priority) falls between the MMC's event dates. The start date of the event is usually the kickoff date and the end date is usually the awards ceremony date.

Additionally, all previous MMC years (2020 to 2024) are now considered. Entries submitted for those years will now have the MMC data; this includes the year, categories, and the wiki page URL. 

<img width="638" height="829" alt="image" src="https://github.com/user-attachments/assets/d3225d58-84bd-4fe6-9eb5-ed5434f2dd23" />

MMC years are stored in JSON configuration files, and new MMC years can be added in this way.

Resolves #54 