### PR TITLE
fix(og): address incorrect urls for thumbnail and json

### DIFF
--- a/helpers/preprocessing.js
+++ b/helpers/preprocessing.js
@@ -74,6 +74,9 @@ function preProcessWorld(json) {
   } else {
     json.thumbnailUri = NO_THUMBNAIL_URL;
   }
+  // Handle thumbnailUri and thumbnailUrl quirk by also assigning thumbnailUrl for worlds.
+  json.thumbnailUrl = json.thumbnailUri;
+  // TODO: there should be a standardized variable name for thumbnail urls.
 
   json.isFeatured = !!json.submissions?.[0]?.featured;
   // Convert to UTC to have a standard timezone

--- a/routes/index.js
+++ b/routes/index.js
@@ -140,14 +140,22 @@ async function handle(type, req, res, next, reqInit = undefined) {
  * @return BaseWorldSessionInfo
  */
 function addMetadata(pageType, json, req, reqInit = undefined) {
-  const urlPath = req.getUrl();
+  const urlPath = new URL(req.getUrl());
+
+  const ogThumbnailUrl = new URL(urlPath);
+  if (json.thumbnailUrl !== NO_THUMBNAIL_URL) {
+    ogThumbnailUrl.pathname += '/thumbnail';
+  } else {
+    ogThumbnailUrl.pathname = NO_THUMBNAIL_URL;
+  }
+
   return Object.assign(json, {
     bodyClass: pageType,
     pageType,
     query: req.query,
     params: req.params,
     urlPath,
-    ogThumbnailUrl: json.thumbnailUrl !== NO_THUMBNAIL_URL ? `${urlPath}/thumbnail` : NO_THUMBNAIL_URL,
+    ogThumbnailUrl,
     apiInitBody: JSON.parse(reqInit?.body ?? null)
   });
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -149,6 +149,9 @@ function addMetadata(pageType, json, req, reqInit = undefined) {
     ogThumbnailUrl.pathname = NO_THUMBNAIL_URL;
   }
 
+  const jsonUrl = new URL(urlPath);
+  jsonUrl.pathname += '/json';
+
   return Object.assign(json, {
     bodyClass: pageType,
     pageType,
@@ -156,6 +159,7 @@ function addMetadata(pageType, json, req, reqInit = undefined) {
     params: req.params,
     urlPath,
     ogThumbnailUrl,
+    jsonUrl,
     apiInitBody: JSON.parse(reqInit?.body ?? null)
   });
 }

--- a/views/session.pug
+++ b/views/session.pug
@@ -4,7 +4,7 @@ block head
     meta(property="og:image" content=ogThumbnailUrl)
     meta(property="og:description" content!=description)
     meta(name="twitter:card" content="summary_large_image")
-    link(type="application/json+oembed" href=urlPath + "/json")
+    link(type="application/json+oembed" href=jsonUrl)
 
 block content
     h1 !{name}

--- a/views/sessionList.pug
+++ b/views/sessionList.pug
@@ -2,7 +2,7 @@ extends layout
 
 block head
   meta(property="og:description" content="Active sessions on Resonite")
-  link(type="application/json+oembed" href=`${urlPath}json`)
+  link(type="application/json+oembed" href=jsonUrl)
   link(rel='stylesheet' href='/stylesheets/sessionList.css')
 
 block content

--- a/views/world.pug
+++ b/views/world.pug
@@ -7,7 +7,7 @@ block head
     meta(property="og:image" content=ogThumbnailUrl)
     meta(property="og:description" content=description)
     meta(name="twitter:card" content="summary_large_image")
-    link(type="application/json+oembed" href=urlPath + "/json")
+    link(type="application/json+oembed" href=jsonUrl)
 
 block content
     h1 !{name}

--- a/views/worldList.pug
+++ b/views/worldList.pug
@@ -5,7 +5,7 @@ include mixins/pagination.pug
 
 block head
   meta(property="og:description" content="Published worlds on Resonite")
-  link(type="application/json+oembed" href=`${urlPath}json`)
+  link(type="application/json+oembed" href=jsonUrl)
   link(rel='stylesheet' href='/stylesheets/worldList.css')
   link(rel='stylesheet' href='/stylesheets/searchbox.css')
   link(rel='stylesheet' href='/stylesheets/pagination.css')


### PR DESCRIPTION
This PR addresses the incorrect URL used for OpenGraph, specifically for Thumbnail and for JSON in Worlds and Sessions.

For Thumbnail, `/thumbnail` will now be appended before the URL query for thumbnail URLs.

For JSON, `/json` is now correctly appended to the JSON URL for Worlds and Sessions pages and appended before the URL query.

Fixes #66 
Fixes #67 