### PR TITLE
fix(og): Strip tags from open graph world descriptions

### DIFF
--- a/helpers/preprocessing.js
+++ b/helpers/preprocessing.js
@@ -6,6 +6,16 @@ function sanitizeHTML(input) {
 }
 
 /**
+ * Removes all tags from the given text
+ *
+ * @param {string} input The text to strip tags from.
+ * @returns The processed text that was sanitized.
+ */
+function stripTags(input) {
+    return DOMPurify.sanitize(input, {ALLOWED_TAGS: []});
+}
+
+/**
  * Converts the world or session name to its HTML equivalent.
  *
  * @param {string} name The name of the world or session to sanitize.
@@ -66,6 +76,9 @@ function preProcessSessionList(json, count){
  */
 function preProcessWorld(json) {
   if (json.description) {
+    // Sanitize the Open Graph meta description from tags
+    json.ogDescription = stripTags(json.description);
+    
     json.description = preProcessName(json.description);
   }
 
@@ -125,9 +138,7 @@ function addMetadata(json) {
 export function preProcess(json, type) {
 
   if (type !== "sessionList" && json.name) {
-    json.title = DOMPurify.sanitize(json.name, {
-      ALLOWED_TAGS: []
-    }); // No tags in title
+    json.title = stripTags(json.name); // No tags in title
 
     // Handle name for inclusion in the actual page.
     json.name = preProcessName(json.name);

--- a/views/world.pug
+++ b/views/world.pug
@@ -5,7 +5,7 @@ include mixins/mmc.pug
 block head
     meta(property="og:type" content="resonite.world")
     meta(property="og:image" content=ogThumbnailUrl)
-    meta(property="og:description" content=description)
+    meta(property="og:description" content=ogDescription)
     meta(name="twitter:card" content="summary_large_image")
     link(type="application/json+oembed" href=urlPath + "/json")
 


### PR DESCRIPTION
This PR removes all tags from open graph meta descriptions for worlds

For example, this world has color tags in the description that should not be shown when embedded 
https://go.resonite.com/world/U-Nicole-0/R-fa1a6024-82a4-47de-8159-9bac54d42e48

<img width="500" alt="image" src="https://github.com/user-attachments/assets/d8f376cd-a4ea-4838-a609-f837ab0c9e4c" />

---
I have also popped out the page title's sanitize call into a shared function to also use in the ogDescription fix