### PR TITLE
tweak(logo): go to home page instead of Resonite site

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -84,6 +84,12 @@ footer {
   width: 100%;
 }
 
+.logo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .btn {
   box-sizing: border-box;
   appearance: button;

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -17,9 +17,9 @@ html(lang="en")
             @import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
     body(class=bodyClass)
         header.center
-            a(href='https://resonite.com' target='_blank')
-                img(src='/images/resonite.png' alt='Resonite')
-            a(href='/') go.resonite.com
+            a.logo(href='/')
+                img(src='/images/resonite.png' alt='')
+                span go.resonite.com
         main
             block content
                 h1 Placeholder


### PR DESCRIPTION
The PR changes the hyperlink on the logo to go to the home page of `go.resonite.com` instead of the Resonite website. I have found myself clicking on the logo a lot thinking that it will take me back to the home page of `go.resonite.com` when it instead takes me back to `resonite.com`.

Typically, clicking on the site logo should take you to the home page of the site instead of somewhere else. This can be seen in other sites that are a branch of another such as Google Play and GMail. Clicking those logos will take you to the home page of those sites instead of the home page of Google.

