### PR TITLE
tweak(mmc): show section when comp is active or categories not empty

### DIFF
--- a/typedef.d.ts
+++ b/typedef.d.ts
@@ -131,4 +131,6 @@ type MmcConfigSearchResult = {
   mmcConfig: MmcConfig
   /** `true` if the competition tag found in the world's tags is valid (i.e., the casing matches); otherwise, `false`. */
   isValidCompetitionTag: boolean
+  /** `true` if the competition is currently active; otherwise, `false` */
+  isCompetitionActive
 }


### PR DESCRIPTION
This is detailed in #81, but the short version is that the MMC section will no longer show for entries when the following is true:

* Entered the competition with a valid competition tag (e.g., mmc23, mmc24, mmc25).
* Entered without any categories specified (e.g., esd, art, meme, other, tau).
* The entered competition is no longer active.

Resolves #81 