### PR TITLE
feat(world): add featured world badge to world info page

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -229,3 +229,22 @@ footer {
   margin-right: 0.4em;
 }
 
+.badge {
+  padding: 4px 8px;
+  margin: 0px 5px 10px;
+  
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 4px;
+
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+.badge a {
+  color: unset;
+}
+.badge-yellow {
+  background-color: var(--color-sub-yellow);
+  color: var(--color-hero-yellow);
+}

--- a/views/world.pug
+++ b/views/world.pug
@@ -1,6 +1,7 @@
 extends layout
 
 include mixins/mmc.pug
+include mixins/svg.pug
 
 block head
     meta(property="og:type" content="resonite.world")
@@ -11,8 +12,13 @@ block head
 
 block content
     h1 !{name}
-
-    .center 
+    
+    if isFeatured
+        h2.badge.badge-yellow
+            +svg('/images/reso_featured_ribbon.svg#featured_ribbon')(aria-hidden=true)
+            a(href="https://wiki.resonite.com/Category:Featured_Worlds") Featured World
+    
+    .center
         img(src=thumbnailUri alt=`A preview image of the '${title}' world.` onerror=`this.onerror=null; this.src='${noThumbnailUrl}';`)
 
     dl.infobox


### PR DESCRIPTION
Adds a badge under a featured world's title that indicates the world is featured
This badge also links to the [resonite wiki on featured worlds](https://wiki.resonite.com/Category:Featured_Worlds)

The badge snippet should probably be pulled out into a mixin but I wasn't sure how to go about setting the color in that case

Resolves #72

<img width="495" height="269" alt="image" src="https://github.com/user-attachments/assets/28f7bb36-fca0-420d-960b-96624efedf0f" />

https://github.com/user-attachments/assets/8cd98b72-9b78-4da3-8be6-c2f4c5df191d