### PR TITLE
feat(world-list): add featured only world search requests

### DIFF
--- a/helpers/search.js
+++ b/helpers/search.js
@@ -6,9 +6,10 @@ const MAX_RESULT_COUNT = 20;
  *
  * @param {string} searchStr The string used to search for worlds.
  * @param {number} pageIndex The normalized offset that will be multiplied by the count.
+ * @param {boolean} onlyFeatured `true` if only featured worlds should be returned from the results; otherwise, `false`.
  * @return {RecordApiSearchParameters} The search parameters that can be used to search for particular worlds.
  */
-function createWorldSerachParams(searchStr, pageIndex) {
+function createWorldSerachParams(searchStr, pageIndex, onlyFeatured) {
   const searchTerms = searchStr.trim()
     .split(/\s+/)
     .filter(term => !!term)
@@ -36,12 +37,13 @@ function createWorldSerachParams(searchStr, pageIndex) {
     count: MAX_RESULT_COUNT,
     offset: MAX_RESULT_COUNT * pageIndex,
     private: false,
+    onlyFeatured,
     sortBy: 'FirstPublishTime',
     sortDirection: 'Descending',
     submittedTo: 'G-Resonite',
     optionalTags,
     requiredTags,
-    excludedTags
+    excludedTags,
   };
 }
 
@@ -52,14 +54,14 @@ function createWorldSerachParams(searchStr, pageIndex) {
  * @param {WorldSearchRequestParameters} params The additional search parameters specificed by the user.
  * @return {RequestInit} The request message that is created
  */
-export function createSearchRequestInit({ term, pageIndex }) {
+export function createSearchRequestInit({ term, pageIndex, featuredOnly }) {
   return {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'
     },
     body: JSON.stringify(
-      createWorldSerachParams(term ?? '', pageIndex ?? 0)
+      createWorldSerachParams(term ?? '', pageIndex ?? 0, featuredOnly != null)
     )
   };
 }

--- a/public/stylesheets/searchbox.css
+++ b/public/stylesheets/searchbox.css
@@ -1,13 +1,32 @@
 :root {
   --srch-input-spacing: 8px;
+  --srch-form-gap: 8px;
 }
 
 .search {
-  display: flex;
-  align-items: center;
+  display: grid;
+  grid-template-columns: auto 0;
+  grid-template-areas:
+    "search-input search-btn"
+    "search-other search-other";
+  row-gap: var(--srch-form-gap);
   position: relative;
   margin: 16px 0 24px;
-  cursor: url("/images/cursors/SVG/Color_TypingCursor.svg") 8 8, default;
+}
+
+.search__search-input-block,
+.search__search-other-block {
+  display: flex;
+  align-items: center;
+  flex: 1 1 100%;
+}
+
+.search__search-input-block {
+  grid-area: search-input;
+}
+
+.search__search-other-block {
+  grid-area: search-other;
 }
 
 .search__textinput {
@@ -23,8 +42,12 @@
 }
 
 .search__btn {
-  position: absolute;
-  right: 0;
-  margin: 0 var(--srch-input-spacing) 0 0;
+  grid-area: search-btn;
+  align-self: center;
   background: none;
+}
+
+.search__btn,
+.search__btn:active {
+  transform: translateX(calc(-100% - var(--srch-input-spacing)));
 }

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -84,6 +84,15 @@ footer {
   width: 100%;
 }
 
+input::placeholder {
+  user-select: none;
+}
+
+input[type=checkbox]+label {
+  cursor: pointer;
+  user-select: none;
+}
+
 .btn {
   box-sizing: border-box;
   appearance: button;

--- a/typedef.d.ts
+++ b/typedef.d.ts
@@ -17,8 +17,12 @@ type RecordApiSearchParameters = {
 }
 
 type WorldSearchRequestParameters = import('express-serve-static-core').ParamsDictionary | {
+  /** The search string that determines what worlds to return in the results. */
   term?: string
+  /** The current page number that determines which part of the world results to return. The number `0` is the first page. */
   pageIndex: number
+  /** `true` if only featured worlds should be returned from the results; otherwise, `false`. */
+  featuredOnly: boolean
 }
 
 type WorldSearchResult = {

--- a/views/mixins/searchbox.pug
+++ b/views/mixins/searchbox.pug
@@ -2,7 +2,10 @@ include svg.pug
 
 mixin searchbox(term, label='Search')
   form(method='GET')&attributes(attributes).search
-    label(for='term').visually-hidden #{label}
-    input(type='text' name='term' id='search' value=term placeholder=`${label}...`).search__textinput
+    .search__search-input-block
+      label(for='search').visually-hidden #{label}
+      input(type='text' name='term' id='search' value=term placeholder=`${label}...`).search__textinput
+    .search__search-other-block
+      block
     +icon-btn('Search')(type='submit').btn--blue.search__btn
       +svg('/images/reso_magnifying_glass.svg#magnifying_glass')

--- a/views/worldList.pug
+++ b/views/worldList.pug
@@ -11,8 +11,13 @@ block head
   link(rel='stylesheet' href='/stylesheets/pagination.css')
 
 block content
+  - const featuredOnly = query.featuredOnly?.match(/^1?$/)
+
   h1 World List
   +searchbox(query.term, 'Search for worlds')(action='')
+    .search__input-block
+      input(type='checkbox' name='featuredOnly' id='featuredOnly' value='1' checked=featuredOnly)
+      label(for='featuredOnly') Featured Only
   hr
   if (records.length)
     ol.listing


### PR DESCRIPTION
This PR adds the featured only worlds search requests to the world list. This PR is in response to #85  seeing the work done in #85 and how the **Featured World** badge is currently clickable. For now, the UI for it is just a simple checkbox on the bottom of the search input field.

<img width="644" height="317" alt="image" src="https://github.com/user-attachments/assets/d07f0caa-ff69-4006-a1c7-d3ac4b62e469" />

Unless there is something critical found or if #85 is merged in before this update, this will be the last PR from me until the architecture is redesigned in order to prevent disruptions.
