### PR TITLE
fix(style): add missing end brace

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -105,6 +105,7 @@ input::placeholder {
 input[type=checkbox]+label {
   cursor: pointer;
   user-select: none;
+}
 
 input[type=text] {
   cursor: var(--cursor-text);


### PR DESCRIPTION
During the merging of PRs, it appears that an end brace was left out. Due to this, it prevents `style.css` from being rendered correctly.