### PR TITLE
chore: ignore dev deps for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    allow:
+      - dependency-type: "production" # dependencies
+    ignore:
+      - dependency-type: "development" # devDependencies


### PR DESCRIPTION
This PR updates dependabot to ignore dev dependencies that currently have a new version. It is understandable for dependabot to make PRs for production updates, but dev dependencies updates can be performed once in awhile. As it should, this configuration **WILL NOT** prevent any security vulnerabilities reported for a dev dependency and will make PRs for that dependency.