### PR TITLE
chore: fix incorrect property name for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,6 @@ updates:
     schedule:
       interval: "weekly"
     allow:
-      - dependency-type: "production" # dependencies
+      - dependency-name: "production" # dependencies
     ignore:
-      - dependency-type: "development" # devDependencies
+      - dependency-name: "development" # devDependencies

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix",
     "format": "prettier --check .",
-    "format:fix": "prettier --write ."
+    "format:fix": "prettier --write .",
+    "verify:dependabot-schema": "npx @bugron/validate-dependabot-yaml ./.github/dependabot.yml"
   },
   "exports": "./start.js",
   "dependencies": {


### PR DESCRIPTION
This PR corrects the dependabot config file since the wrong property name was used. The PR also adds an additional script command to verify the dependabot config file if someone should want to modify that file in the future.