### PR TITLE
tweak(style): adjust styling and element formatting

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,7 +36,7 @@ app.use(function (req, res, next) {
 });
 
 // error handler
-app.use(function (err, req, res, next) {
+app.use(function (err, req, res) {
   // set locals, only providing error in development
   res.locals.message = err.message;
   res.locals.error = err;

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -61,7 +61,8 @@ body {
   padding: 20px 10px 0;
 }
 
-a {
+a,
+input[type="checkbox"] {
   cursor: var(--cursor-pointer);
 }
 
@@ -109,7 +110,7 @@ input::placeholder {
 }
 
 input[type="checkbox"] + label {
-  cursor: pointer;
+  cursor: var(--cursor-pointer);
   user-select: none;
 }
 

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -27,8 +27,10 @@
   --color-mid-orange: #976c3d;
   --color-sub-orange: #48392a;
   --color-dark-orange: #292423;
-  --color-mmc-sub: #8f0089;
-  --color-mmc-hero: #ff93fb;
+  --color-hero-mmc: #ff93fb;
+  --color-mid-mmc: #ab44a8;
+  --color-sub-mmc: #8f0089;
+  --color-dark-mmc: #292329;
   --background-body: #11151d;
   --border-radius: 8px;
   --btn--icon-only-size: 36px;
@@ -297,6 +299,7 @@ dd {
 }
 .badge a {
   color: unset;
+  text-decoration: none;
 }
 .badge svg,
 .badge img {
@@ -308,7 +311,19 @@ dd {
   background-color: var(--color-sub-yellow);
   color: var(--color-hero-yellow);
 }
+.badge-clickable.badge-yellow:hover {
+  background-color: var(--color-mid-yellow);
+}
+.badge-clickable.badge-yellow:active {
+  background-color: var(--color-dark-yellow);
+}
 .badge-mmc {
-  background-color: var(--color-mmc-sub);
-  color: var(--color-mmc-hero);
+  background-color: var(--color-sub-mmc);
+  color: var(--color-hero-mmc);
+}
+.badge-clickable.badge-mmc:hover {
+  background-color: var(--color-mid-mmc);
+}
+.badge-clickable.badge-mmc:active {
+  background-color: var(--color-dark-mmc);
 }

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -58,7 +58,7 @@ body {
   flex: 1;
   box-sizing: border-box;
   max-width: 820px;
-  padding: 20px 10px;
+  padding: 20px 10px 0;
 }
 
 a {
@@ -269,11 +269,20 @@ dd {
 .select-all {
   user-select: all;
 }
-.footer-links a {
-  margin-left: 0.4em;
-  margin-right: 0.4em;
+.footer-links {
+  display: flex;
+  list-style: none;
+  margin: 10px 0 20px;
+  padding: 0;
 }
-
+.footer-links > .footer-link {
+  display: flex;
+  box-sizing: border-box;
+  padding: 0 0.4em;
+}
+.footer-links > .footer-link:not(:last-child) {
+  border-right: 2px solid currentColor;
+}
 .badge-list {
   display: inline-flex;
   gap: 10px;

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -32,6 +32,8 @@
   --background-body: #11151d;
   --border-radius: 8px;
   --btn--icon-only-size: 36px;
+  --badge-content-gap: 5px;
+  --badge-image-size: 1.4em;
   --cursor-default: url("/images/cursors/default_cursor.svg") 8 8, default;
   --cursor-pointer: url("/images/cursors/interact_cursor.svg") 8 8, pointer;
   --cursor-text: url("/images/cursors/typing_cursor.svg") 10 10, text;
@@ -271,28 +273,36 @@ dd {
 }
 
 .badge-list {
-  list-style: none;
-  margin: 0px 0px 10px;
-  padding: 0px;
   display: inline-flex;
+  gap: 10px;
+  list-style: none;
+  margin: 0 0 10px;
+  padding: 0;
 }
 .badge {
-  padding: 4px 8px;
-  margin: 0px 5px;
   border-radius: 8px;
   display: inline-flex;
   align-items: flex-end;
   gap: 4px;
   font-size: 1.4rem;
   font-weight: 600;
+  transition: background-color var(--animation-duration) linear;
+  user-select: none;
+}
+.badge .badge-content {
+  display: flex;
+  align-items: center;
+  gap: var(--badge-content-gap);
+  padding: 4px 8px;
 }
 .badge a {
   color: unset;
 }
 .badge svg,
 .badge img {
-  width: 1.4em;
-  height: 1.4em;
+  width: var(--badge-image-size);
+  height: var(--badge-image-size);
+  pointer-events: none;
 }
 .badge-yellow {
   background-color: var(--color-sub-yellow);

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -274,24 +274,23 @@ dd {
   list-style: none;
   margin: 0px 0px 10px;
   padding: 0px;
-  display: inline-flex
+  display: inline-flex;
 }
 .badge {
   padding: 4px 8px;
   margin: 0px 5px;
-  
   border-radius: 8px;
   display: inline-flex;
   align-items: flex-end;
   gap: 4px;
-
   font-size: 1.4rem;
   font-weight: 600;
 }
 .badge a {
   color: unset;
 }
-.badge svg, .badge img {
+.badge svg,
+.badge img {
   width: 1.4em;
   height: 1.4em;
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -12,7 +12,7 @@ import { NO_THUMBNAIL_URL } from "../helpers/constants.js";
 var router = express.Router();
 
 /* GET home page. */
-router.get("/", function (req, res, next) {
+router.get("/", function (req, res) {
   res.render("index", {
     title: "go.resonite.com Home",
   });
@@ -322,7 +322,7 @@ function getOpenGraphTitle(type) {
 }
 
 var contributorsJson = null;
-function renderCredits(req, res, next) {
+function renderCredits(req, res) {
   if (contributorsJson !== null) return res.render("credits", contributorsJson);
 
   const contributorsFile = fs.readFileSync("./.all-contributorsrc");

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -30,10 +30,10 @@ html(lang="en")
     style.
       @import url("https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap");
   body(class=bodyClass)
-    header.center.logo
-      a(href="/")
+    header.center
+      a.logo(href="/")
         img(src="/images/resonite.png", alt="")
-      a(href="/") go.resonite.com
+        | go.resonite.com
     main
       block content
         h1 Placeholder

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -41,9 +41,10 @@ html(lang="en")
       p.center
         span Copyright ©
         a(href="https://yellowdogman.com/imprint.html") Yellow Dog Man Studios s.r.o.
-      span.center.small.footer-links
-        a(href="/credits") Credits
-        | |
-        a(href="/") Home
-        | |
-        a(href="https://resonite.com") Main Website
+      ul.center.small.footer-links
+        li.footer-link
+          a(href="/credits") Credits
+        li.footer-link
+          a(href="/") Home
+        li.footer-link
+          a(href="https://resonite.com") Main Website

--- a/views/mixins/badge.pug
+++ b/views/mixins/badge.pug
@@ -1,7 +1,7 @@
+include conditional-a.pug
+
 mixin badge(text, colorName, url)
   li.badge(class=`badge-${colorName}`)
-    block
-    if url
-      a(href=url) #{ text }
-    else
+    +conditional-a(url).badge-content
+      block
       | #{ text }

--- a/views/mixins/badge.pug
+++ b/views/mixins/badge.pug
@@ -1,7 +1,7 @@
 mixin badge(text, colorName, url)
   li.badge(class=`badge-${colorName}`)
     block
-    if(url)
+    if url
       a(href=url) #{ text }
     else
       | #{ text }

--- a/views/mixins/badge.pug
+++ b/views/mixins/badge.pug
@@ -1,7 +1,7 @@
 include conditional-a.pug
 
 mixin badge(text, colorName, url)
-  li.badge(class=`badge-${colorName}`)
+  li.badge(class=[`badge-${colorName}`, { "badge-clickable": !!url }])
     +conditional-a(url).badge-content
       block
       | #{ text }

--- a/views/mixins/conditional-a.pug
+++ b/views/mixins/conditional-a.pug
@@ -1,0 +1,7 @@
+mixin conditional-a(url)
+  if url
+    a(href=url)&attributes(attributes)
+      block
+  else
+    span&attributes(attributes)
+      block

--- a/views/session.pug
+++ b/views/session.pug
@@ -18,13 +18,13 @@ block content
 
   dl.infobox
     .row
-      dt Host:
+      dt Host:#{ ' ' }
       dd #{ hostUsername }
     .row
-      dt Version:
+      dt Version:#{ ' ' }
       dd #{ appVersion }
     .row
-      dt Users (#{ totalJoinedUsers }/#{ maxUsers }): 
+      dt Users (#{ totalJoinedUsers }/#{ maxUsers }):#{ ' ' }
       dd #{ sessionUsers.map(user => user.username).join(", ") }
   .center
     a.btn(href=`ressession:///${sessionId}`) Join Session!

--- a/views/world.pug
+++ b/views/world.pug
@@ -20,7 +20,7 @@ block content
         +svg("/images/reso_featured_ribbon.svg#featured_ribbon")(aria-hidden)
     if mmc
       +badge("MMC World", "mmc", "https://wiki.resonite.com/MMC")
-        img(src="/images/MMC.png")(aria-hidden)
+        img(src="/images/MMC.png", alt="")
 
   .center
     img(

--- a/views/world.pug
+++ b/views/world.pug
@@ -31,30 +31,30 @@ block content
 
   dl.infobox
     .row
-      dt By:
+      dt By:#{ ' ' }
       dd #{ ownerName }
     .row
-      dt Description:
+      dt Description:#{ ' ' }
       dd !{ description }
     .row
-      dt Created on:
+      dt Created on:#{ ' ' }
       dd #{ creationTime }
     if isPublished
       .row
-        dt First published on:
+        dt First published on:#{ ' ' }
         dd #{ firstPublishTime }
     else
       .row
-        dt Published:
+        dt Published:#{ ' ' }
         dd.warning Not Published
     .row
-      dt Last modified on:
+      dt Last modified on:#{ ' ' }
       dd #{ lastModificationTime }
     .row
-      dt Visits:
+      dt Visits:#{ ' ' }
       dd #{ visits }
     .row
-      dt Tags:
+      dt Tags:#{ ' ' }
       dd #{ tags.join(", ") }
   .center
     a.btn(href=`resrec:///${ownerId}/${id}`) Open World!

--- a/views/world.pug
+++ b/views/world.pug
@@ -13,14 +13,14 @@ block head
 
 block content
   h1 !{ name }
-  
+
   ul.badge-list
     if isFeatured
-      +badge('Featured World', 'yellow', 'https://wiki.resonite.com/Category:Featured_Worlds')
-        +svg('/images/reso_featured_ribbon.svg#featured_ribbon')(aria-hidden=true)
+      +badge("Featured World", "yellow", "https://wiki.resonite.com/Category:Featured_Worlds")
+        +svg("/images/reso_featured_ribbon.svg#featured_ribbon")(aria-hidden)
     if mmc
-      +badge('MMC World', 'mmc', 'https://wiki.resonite.com/MMC')
-        img(src='/images/MMC.png')(aria-hidden=true)
+      +badge("MMC World", "mmc", "https://wiki.resonite.com/MMC")
+        img(src="/images/MMC.png")(aria-hidden)
 
   .center
     img(


### PR DESCRIPTION
This PR provides adjustments to some styling and rearranges the HTML of certain elements.

* Fixes the missing trailing space after the infobox description term.
* Fixes the layout of the badges by switching from `margin` to `gap`.
* Fixes the anchor tag on the new badges to surround the entire badge instead of just the text
* Adds a new hover effect for the badge.
* Reverts the logo back to a previous version that I had originally, combining the two anchor tags into one.
* Changes the footer slightly.
  * Updates the footer element to use an unordered list for semantic reasons.
  * Changes the footer style to use CSS instead of the pipe text.
* Adds the custom cursor to checkbox inputs and labels.
* Adds `conditional-a` pug mixin that will use either an `a` or `span` tag depending on if the provided `url` is null or not.


Despite these changes, the website still looks virtually the same.