### PR TITLE
feat(mmc): add logic to recognize official event worlds used

### DIFF
--- a/helpers/mmc.js
+++ b/helpers/mmc.js
@@ -70,9 +70,7 @@ function* matchCategories(worldTags, categories) {
  * @returns {WorldInfo} The mutated world record that was passed in.
  */
 export function addMMC(worldRecord) {
-  if (worldRecord.ownerId === "G-Creator-Jam") {
-    return worldRecord;
-  }
+  const isOfficialWorld = worldRecord.ownerId === "G-Creator-Jam";
 
   const { firstPublishTime, creationTime } = worldRecord;
   const tags = new Set(worldRecord.tags);
@@ -83,19 +81,27 @@ export function addMMC(worldRecord) {
     return worldRecord;
   }
 
-  const categories = new Map(matchCategories(tags, mmcConfig.categories))
-    .values()
-    .toArray();
-  const isActiveCompetitionEntry = isCompetitionActive || categories.length > 0;
+  const categories = isOfficialWorld
+    ? []
+    : new Map(matchCategories(tags, mmcConfig.categories)).values().toArray();
+  const isActiveCompetitionEntry =
+    isOfficialWorld || isCompetitionActive || categories.length > 0;
 
   if (!isActiveCompetitionEntry) {
     return worldRecord;
   }
 
+  const mmcType = isOfficialWorld
+    ? "official"
+    : isValidCompetitionTag
+      ? "entry"
+      : "error";
+
   return Object.assign(worldRecord, {
     mmc: {
       year: mmcConfig.year,
       wikiPath: mmcConfig.wikiPath,
+      type: mmcType,
       entered: isValidCompetitionTag,
       categories: isValidCompetitionTag
         ? // Need to handle MMC 2020 categories this way due to the dual casings for categories (e.g., "world and World", "avatar and Avatar", and "other and Other")

--- a/views/mixins/mmc.pug
+++ b/views/mixins/mmc.pug
@@ -4,21 +4,24 @@ mixin mmcMixin(mmcData)
       | MMC #{ mmcData.year } Information
       img(src="/images/CreatorJam.png")
     ul
-      if mmcData.entered
-        li ✅ This world is entered into MMC #{ mmcData.year }!
-        if isPublished
-          li ✅ This world is published!
-        else
-          li.warning ❌ This world is #[strong NOT] published!
-        if mmcData.categories.length > 0
-          li It is entered into the following Categories:
-            ul
-              each category in mmcData.categories
-                li ✅ !{ category.title }
-        if mmcData.categories.length > 1
-          li.warning ❌ It is entered into more than one category.
-        if mmcData.categories.length == 0
-          li.warning ❌ It is #[strong NOT] entered into any categories.
-      else
-        li.warning ❌ This world is #[strong NOT] entered into MMC #{ mmcData.year }, due to: !{ mmcData.error }
+      case mmcData.type
+        when "official"
+          li This is an official event world for MMC #{ mmcData.year } that was created by Creator Jam.
+        when "entry"
+          li ✅ This world is entered into MMC #{ mmcData.year }!
+          if isPublished
+            li ✅ This world is published!
+          else
+            li.warning ❌ This world is #[strong NOT] published!
+          if mmcData.categories.length > 0
+            li It is entered into the following Categories:
+              ul
+                each category in mmcData.categories
+                  li ✅ !{ category.title }
+          if mmcData.categories.length > 1
+            li.warning ❌ It is entered into more than one category.
+          if mmcData.categories.length == 0
+            li.warning ❌ It is #[strong NOT] entered into any categories.
+        default
+          li.warning ❌ This world is #[strong NOT] entered into MMC #{ mmcData.year }, due to: !{ mmcData.error }
     p See #[a(href=`https://wiki.resonite.com/${mmcData.wikiPath}`) our wiki] for more information on MMC #{ mmcData.year }.


### PR DESCRIPTION
This PR adjusts the MMC processing logic to include official event worlds created for MMC by Creator Jam group. Originally, these worlds were being ignored in order to avoid having them listed as contest entries. However, with the advent of the world badges, these official event worlds should have the MMC World badge as well. Additionally, the MMC Information section will state that the world is an official event world for that particular MMC year.

Resolves #97 