### PR TITLE
fix(route): address regression of error page

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,7 +36,7 @@ app.use(function (req, res, next) {
 });
 
 // error handler
-app.use(function (err, req, res) {
+app.use(function (err, req, res, _next) {
   // set locals, only providing error in development
   res.locals.message = err.message;
   res.locals.error = err;

--- a/app.js
+++ b/app.js
@@ -46,7 +46,13 @@ app.use(function (err, req, res, _next) {
 
   // render the error page
   res.status(err.status || 500);
-  res.render("error");
+
+  switch (err.contentType) {
+    case "json":
+      return res.send(err.message);
+    default:
+      return res.render("error");
+  }
 });
 
 export default app;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,6 +26,7 @@ export default defineConfig(
   {
     rules: {
       "prettier/prettier": "off",
+      "no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
     },
   },
 );


### PR DESCRIPTION
This PR fixes the presentational error page not being rendered when an HTTP error is encountered while browsing a world or session. This is due to the `eslint` rule where it will flag unused arguments and variables. Apparently, an express middleware expects four arguments for the function to be defined regardless of if they are being used or not. Due to this, the `eslint` rule was tweaked to ignore arguments and variables that start with an `_`, which it is a standard for declaring unused variables.

I have also added a check for any route that returns `json` content to render the plain text page if it should face any errors; I feel this is more appropriate for that.

Fixes #103 