### PR TITLE
fix(mmc): use correct value comparison for competition dates

### DIFF
--- a/helpers/mmc.js
+++ b/helpers/mmc.js
@@ -31,8 +31,8 @@ function findMmcConfig(tags, entryDate) {
   }
 
   const isCompetitionActive =
-    Date.now() >= mmcConfig?.startDate.getMilliseconds() &&
-    Date.now() < mmcConfig?.endDate.getMilliseconds();
+    Date.now() >= mmcConfig?.startDate.getTime() &&
+    Date.now() < mmcConfig?.endDate.getTime();
 
   return {
     mmcConfig,


### PR DESCRIPTION
This PR aims to fix the MMC section to show entries that have entered via a valid competition tag (i.e., mmc25, mmc26) but contain incorrect category tags during an active competition period. This mainly affects category tags that were either misspelled or missing a required sub-category (i.e., world, avatar, other). As an example, the current world shown below has entered for MMC26; however, it contains a misspelled tag.

<img width="663" height="827" alt="image" src="https://github.com/user-attachments/assets/89f680d8-1f24-46ed-b3d4-b98a5a2957a0" />

With this fix, the section will properly show when it is still an active competition.

<img width="537" height="188" alt="image" src="https://github.com/user-attachments/assets/82e5c284-ed02-46b2-a126-0403f2c87318" />
